### PR TITLE
Remove UnsignedInt import

### DIFF
--- a/src/mpmc/bounded/imp.rs
+++ b/src/mpmc/bounded/imp.rs
@@ -3,7 +3,7 @@
 //! 1024cores does not handle ABA!
 
 use std::{ptr, mem};
-use std::num::{UnsignedInt, Int};
+use std::num::{Int};
 use std::sync::atomic::{AtomicUsize, AtomicBool};
 use std::sync::atomic::Ordering::{SeqCst};
 use std::sync::{Mutex, Condvar};

--- a/src/mpmc/bounded/imp.rs
+++ b/src/mpmc/bounded/imp.rs
@@ -3,7 +3,7 @@
 //! 1024cores does not handle ABA!
 
 use std::{ptr, mem};
-use std::num::{UnsignedInt, Int};
+use std::num::Int;
 use std::sync::atomic::{AtomicUsize, AtomicBool};
 use std::sync::atomic::Ordering::{SeqCst};
 use std::sync::{Mutex, Condvar};

--- a/src/mpsc/bounded_fast/imp.rs
+++ b/src/mpsc/bounded_fast/imp.rs
@@ -1,5 +1,5 @@
 use std::{ptr, mem, cmp};
-use std::num::{UnsignedInt, Int};
+use std::num::{Int};
 use std::sync::atomic::{AtomicUsize, AtomicBool};
 use std::sync::atomic::Ordering::{SeqCst};
 use std::sync::{Mutex, Condvar};

--- a/src/mpsc/bounded_fast/imp.rs
+++ b/src/mpsc/bounded_fast/imp.rs
@@ -1,5 +1,5 @@
 use std::{ptr, mem, cmp};
-use std::num::{UnsignedInt, Int};
+use std::num::Int;
 use std::sync::atomic::{AtomicUsize, AtomicBool};
 use std::sync::atomic::Ordering::{SeqCst};
 use std::sync::{Mutex, Condvar};

--- a/src/spmc/bounded_fast/imp.rs
+++ b/src/spmc/bounded_fast/imp.rs
@@ -1,5 +1,5 @@
 use std::{ptr, mem, cmp};
-use std::num::{UnsignedInt, Int};
+use std::num::{Int};
 use std::sync::atomic::{AtomicUsize, AtomicBool};
 use std::sync::atomic::Ordering::{SeqCst};
 use std::sync::{Mutex, Condvar};

--- a/src/spmc/bounded_fast/imp.rs
+++ b/src/spmc/bounded_fast/imp.rs
@@ -1,5 +1,5 @@
 use std::{ptr, mem, cmp};
-use std::num::{UnsignedInt, Int};
+use std::num::Int;
 use std::sync::atomic::{AtomicUsize, AtomicBool};
 use std::sync::atomic::Ordering::{SeqCst};
 use std::sync::{Mutex, Condvar};

--- a/src/spsc/bounded/imp.rs
+++ b/src/spsc/bounded/imp.rs
@@ -1,7 +1,7 @@
 //! Implementation of the bounded SPSC channel.
 
 use std::{ptr, mem};
-use std::num::{UnsignedInt, Int};
+use std::num::{Int};
 use std::sync::atomic::{AtomicUsize, AtomicBool};
 use std::sync::atomic::Ordering::{SeqCst};
 use std::sync::{Mutex, Condvar};

--- a/src/spsc/bounded/imp.rs
+++ b/src/spsc/bounded/imp.rs
@@ -1,7 +1,7 @@
 //! Implementation of the bounded SPSC channel.
 
 use std::{ptr, mem};
-use std::num::{UnsignedInt, Int};
+use std::num::Int;
 use std::sync::atomic::{AtomicUsize, AtomicBool};
 use std::sync::atomic::Ordering::{SeqCst};
 use std::sync::{Mutex, Condvar};

--- a/src/spsc/ring_buf/imp.rs
+++ b/src/spsc/ring_buf/imp.rs
@@ -1,5 +1,5 @@
 use std::{ptr, mem};
-use std::num::{UnsignedInt, Int};
+use std::num::{Int};
 use std::sync::atomic::{AtomicUsize, AtomicBool, Ordering};
 use std::sync::{Mutex, Condvar};
 use std::rt::heap::{allocate, deallocate};

--- a/src/spsc/ring_buf/imp.rs
+++ b/src/spsc/ring_buf/imp.rs
@@ -1,5 +1,5 @@
 use std::{ptr, mem};
-use std::num::{UnsignedInt, Int};
+use std::num::Int;
 use std::sync::atomic::{AtomicUsize, AtomicBool, Ordering};
 use std::sync::{Mutex, Condvar};
 use std::rt::heap::{allocate, deallocate};


### PR DESCRIPTION
`UnsignedInt` was recently removed in the stabilization of `std::num`.
