### PR TITLE
Update for nightly rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![crate_name = "comm"]
 #![feature(unsafe_destructor, box_syntax, core, alloc, collections, unsafe_no_drop_flag,
            std_misc)]
-#![cfg_attr(test, feature(old_io, test))]
+#![cfg_attr(test, feature(thread_sleep, test))]
 #![allow(dead_code)]
 
 //! Communication primitives.
@@ -57,8 +57,9 @@
 //! Selecting:
 //!
 //! ```
-//! use std::{thread};
-//! use std::old_io::{timer};
+//! #![feature(std_misc, thread_sleep)]
+//!
+//! use std::thread::{self, sleep};
 //! use std::time::duration::{Duration};
 //! use comm::{spsc};
 //! use comm::select::{Select, Selectable};
@@ -68,7 +69,7 @@
 //!     let (send, recv) = spsc::one_space::new();
 //!     channels.push(recv);
 //!     thread::spawn(move || {
-//!         timer::sleep(Duration::milliseconds(100));
+//!         sleep(Duration::milliseconds(100));
 //!         send.send(i).ok();
 //!     });
 //! }

--- a/src/mpmc/bounded/test.rs
+++ b/src/mpmc/bounded/test.rs
@@ -1,7 +1,6 @@
-use std::old_io::timer::{sleep};
 use std::sync::{Arc};
 use std::time::duration::{Duration};
-use std::{thread};
+use std::thread::{self, sleep};
 use std::sync::atomic::{AtomicUsize};
 use std::sync::atomic::Ordering::{SeqCst};
 

--- a/src/mpsc/bounded_fast/test.rs
+++ b/src/mpsc/bounded_fast/test.rs
@@ -1,6 +1,5 @@
-use std::old_io::timer::{sleep};
 use std::time::duration::{Duration};
-use std::{thread};
+use std::thread::{self, sleep};
 
 use select::{Select, Selectable};
 use {Error};

--- a/src/mpsc/unbounded/imp.rs
+++ b/src/mpsc/unbounded/imp.rs
@@ -42,7 +42,7 @@ struct Node<T: Sendable> {
 impl<T: Sendable> Node<T> {
     // Creates and forgets a new node.
     fn new() -> *mut Node<T> {
-        let mut node = Box::new(Node {
+        let mut node: Box<Node<T>> = Box::new(Node {
             next: AtomicPtr::new(ptr::null_mut()),
             val: None
         });

--- a/src/mpsc/unbounded/test.rs
+++ b/src/mpsc/unbounded/test.rs
@@ -1,7 +1,6 @@
-use std::old_io::timer::{sleep};
 use std::sync::{Arc};
 use std::time::duration::{Duration};
-use std::{thread};
+use std::thread::{self, sleep};
 use std::sync::atomic::{AtomicUsize};
 use std::sync::atomic::Ordering::{SeqCst};
 

--- a/src/select/test.rs
+++ b/src/select/test.rs
@@ -1,6 +1,5 @@
-use std::old_io::timer::{sleep};
 use std::time::duration::{Duration};
-use std::{thread};
+use std::thread::{self, sleep};
 use std::sync::{Arc};
 use std::sync::atomic::{AtomicUsize};
 use std::sync::atomic::Ordering::{SeqCst};

--- a/src/spmc/bounded_fast/test.rs
+++ b/src/spmc/bounded_fast/test.rs
@@ -1,7 +1,6 @@
-use std::old_io::timer::{sleep};
 use std::sync::{Arc};
 use std::time::duration::{Duration};
-use std::{thread};
+use std::thread::{self, sleep};
 use std::sync::atomic::{AtomicUsize};
 use std::sync::atomic::Ordering::{SeqCst};
 

--- a/src/spmc/unbounded/imp.rs
+++ b/src/spmc/unbounded/imp.rs
@@ -44,7 +44,7 @@ struct Node<T: Sendable> {
 impl<T: Sendable> Node<T> {
     // Creates and forgets a new node.
     fn new() -> *mut Node<T> {
-        let mut node = Box::new(Node {
+        let mut node: Box<Node<T>> = Box::new(Node {
             next: AtomicPtr::new(ptr::null_mut()),
             val: None
         });

--- a/src/spmc/unbounded/test.rs
+++ b/src/spmc/unbounded/test.rs
@@ -1,7 +1,6 @@
-use std::old_io::timer::{sleep};
 use std::sync::{Arc};
 use std::time::duration::{Duration};
-use std::{thread};
+use std::thread::{self, sleep};
 use std::sync::atomic::{AtomicUsize};
 use std::sync::atomic::Ordering::{SeqCst};
 

--- a/src/spsc/bounded/test.rs
+++ b/src/spsc/bounded/test.rs
@@ -1,6 +1,5 @@
-use std::old_io::timer::{sleep};
 use std::time::duration::{Duration};
-use std::{thread};
+use std::thread::{self, sleep};
 
 use select::{Select, Selectable};
 use {Error};

--- a/src/spsc/one_space/test.rs
+++ b/src/spsc/one_space/test.rs
@@ -1,6 +1,5 @@
-use std::old_io::timer::{sleep};
 use std::time::duration::{Duration};
-use std::{thread};
+use std::thread::{self, sleep};
 
 use select::{Select, Selectable};
 use {Error};

--- a/src/spsc/ring_buf/test.rs
+++ b/src/spsc/ring_buf/test.rs
@@ -1,6 +1,5 @@
-use std::old_io::timer::{sleep};
 use std::time::duration::{Duration};
-use std::{thread};
+use std::thread::{self, sleep};
 
 use select::{Select, Selectable};
 use {Error};

--- a/src/spsc/unbounded/imp.rs
+++ b/src/spsc/unbounded/imp.rs
@@ -44,7 +44,7 @@ struct Node<'a, T: Sendable+'a> {
 impl<'a, T: Sendable+'a> Node<'a, T> {
     // Creates and forgets a new empty Node.
     fn new() -> *mut Node<'a, T> {
-        let mut node = Box::new(Node {
+        let mut node: Box<Node<T>> = Box::new(Node {
             next: AtomicPtr::new(ptr::null_mut()),
             val: None
         });

--- a/src/spsc/unbounded/test.rs
+++ b/src/spsc/unbounded/test.rs
@@ -1,6 +1,5 @@
-use std::old_io::timer::{sleep};
 use std::time::duration::{Duration};
-use std::{thread};
+use std::thread::{self, sleep};
 
 use select::{Select, Selectable};
 use {Error};


### PR DESCRIPTION
Adds type annotations required by the compiler and moves to `std::thread::sleep` from `std::old_io::timer::sleep`.
