### PR TITLE
Remove unsafe_destructor, which is no longer needed.

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -206,7 +206,6 @@ impl<T> Deref for Arc<T> {
     }
 }
 
-#[unsafe_destructor]
 impl<T> Drop for Arc<T> {
     fn drop(&mut self) {
         // This structure has #[unsafe_no_drop_flag], so this drop glue may run more than
@@ -280,7 +279,6 @@ impl<T> Clone for Weak<T> {
     }
 }
 
-#[unsafe_destructor]
 impl<T> Drop for Weak<T> {
     fn drop(&mut self) {
         let ptr = *self._ptr;
@@ -367,7 +365,6 @@ impl<Trait: ?Sized> Deref for ArcTrait<Trait> {
     }
 }
 
-#[unsafe_destructor]
 impl<Trait: ?Sized> Drop for ArcTrait<Trait> {
     fn drop(&mut self) {
         // This structure has #[unsafe_no_drop_flag], so this drop glue may run more than
@@ -461,7 +458,6 @@ impl<Trait: ?Sized> Clone for WeakTrait<Trait> {
     }
 }
 
-#[unsafe_destructor]
 impl<Trait: ?Sized> Drop for WeakTrait<Trait> {
     fn drop(&mut self) {
         let ptr = *self._ptr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![crate_type = "lib"]
 #![crate_name = "comm"]
-#![feature(unsafe_destructor, box_syntax, core, alloc, collections_drain,
+#![feature(box_syntax, core, alloc, collections_drain,
            unsafe_no_drop_flag, std_misc, filling_drop, wait_timeout_with)]
 #![cfg_attr(test, feature(test, scoped))]
 #![allow(dead_code, trivial_casts, trivial_numeric_casts)]

--- a/src/mpmc/bounded/imp.rs
+++ b/src/mpmc/bounded/imp.rs
@@ -363,12 +363,11 @@ impl<'a, T: Sendable+'a> Packet<'a, T> {
 unsafe impl<'a, T: Sendable+'a> Send for Packet<'a, T> { }
 unsafe impl<'a, T: Sendable+'a> Sync for Packet<'a, T> { }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Packet<'a, T> {
     fn drop(&mut self) {
         let wenr = self.write_end_next_read.load(SeqCst);
         let (write_end, read_start) = decompose_pointer(wenr);
-        
+
         unsafe {
             for i in (0..write_end-read_start) {
                 self.get_mem(read_start + i);

--- a/src/mpmc/bounded/mod.rs
+++ b/src/mpmc/bounded/mod.rs
@@ -83,7 +83,6 @@ impl<'a, T: Sendable+'a> Clone for Channel<'a, T> {
     }
 }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Channel<'a, T> {
     fn drop(&mut self) {
         self.data.remove_peer();

--- a/src/mpsc/bounded_fast/imp.rs
+++ b/src/mpsc/bounded_fast/imp.rs
@@ -289,11 +289,10 @@ impl<'a, T: Sendable+'a> Packet<'a, T> {
 unsafe impl<'a, T: Sendable+'a> Send for Packet<'a, T> { }
 unsafe impl<'a, T: Sendable+'a> Sync for Packet<'a, T> { }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Packet<'a, T> {
     fn drop(&mut self) {
         while self.recv_async(false).is_ok() { }
-        
+
         unsafe {
             deallocate(self.buf as *mut u8,
                        (self.cap_mask as usize + 1) * mem::size_of::<Node<T>>(),

--- a/src/mpsc/bounded_fast/mod.rs
+++ b/src/mpsc/bounded_fast/mod.rs
@@ -48,7 +48,6 @@ impl<'a, T: Sendable+'a> Producer<'a, T> {
 
 unsafe impl<'a, T: Sendable+'a> Send for Producer<'a, T> { }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Producer<'a, T> {
     fn drop(&mut self) {
         self.data.remove_sender();
@@ -90,7 +89,6 @@ impl<'a, T: Sendable+'a> Consumer<'a, T> {
 
 unsafe impl<'a, T: Sendable+'a> Send for Consumer<'a, T> { }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Consumer<'a, T> {
     fn drop(&mut self) {
         self.data.remove_receiver();

--- a/src/mpsc/unbounded/imp.rs
+++ b/src/mpsc/unbounded/imp.rs
@@ -119,7 +119,7 @@ impl<'a, T: Sendable+'a> Packet<'a, T> {
         if !self.have_receiver.load(SeqCst) {
             return Err((val, Error::Disconnected));
         }
-        
+
         // Now this scales right up.
         let new_end = Node::new();
         let write_end = self.write_end.swap(new_end, SeqCst);
@@ -176,7 +176,6 @@ impl<'a, T: Sendable+'a> Packet<'a, T> {
 unsafe impl<'a, T: Sendable+'a> Send for Packet<'a, T> { }
 unsafe impl<'a, T: Sendable+'a> Sync for Packet<'a, T> { }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Packet<'a, T> {
     fn drop(&mut self) {
         while self.recv_async().is_ok() { }

--- a/src/mpsc/unbounded/mod.rs
+++ b/src/mpsc/unbounded/mod.rs
@@ -40,7 +40,6 @@ impl<'a, T: Sendable+'a> Clone for Producer<'a, T> {
     }
 }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Producer<'a, T> {
     fn drop(&mut self) {
         self.data.remove_sender()
@@ -75,7 +74,6 @@ impl<'a, T: Sendable+'a> Consumer<'a, T> {
     }
 }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Consumer<'a, T> {
     fn drop(&mut self) {
         self.data.remove_receiver()

--- a/src/select/imp.rs
+++ b/src/select/imp.rs
@@ -311,7 +311,6 @@ impl<'a> WaitQueue<'a> {
     }
 }
 
-#[unsafe_destructor]
 impl<'a> Drop for WaitQueue<'a> {
     fn drop(&mut self) {
         self.clear();

--- a/src/spmc/bounded_fast/imp.rs
+++ b/src/spmc/bounded_fast/imp.rs
@@ -289,11 +289,10 @@ impl<'a, T: Sendable+'a> Packet<'a, T> {
 unsafe impl<'a, T: Sendable+'a> Send for Packet<'a, T> { }
 unsafe impl<'a, T: Sendable+'a> Sync for Packet<'a, T> { }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Packet<'a, T> {
     fn drop(&mut self) {
         while self.recv_async(false).is_ok() { }
-        
+
         unsafe {
             deallocate(self.buf as *mut u8,
                        (self.cap_mask as usize + 1) * mem::size_of::<Node<T>>(),

--- a/src/spmc/bounded_fast/mod.rs
+++ b/src/spmc/bounded_fast/mod.rs
@@ -48,7 +48,6 @@ impl<'a, T: Sendable+'a> Producer<'a, T> {
 
 unsafe impl<'a, T: Sendable+'a> Send for Producer<'a, T> { }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Producer<'a, T> {
     fn drop(&mut self) {
         self.data.remove_sender();
@@ -90,7 +89,6 @@ impl<'a, T: Sendable+'a> Clone for Consumer<'a, T> {
     }
 }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Consumer<'a, T> {
     fn drop(&mut self) {
         self.data.remove_receiver();

--- a/src/spmc/unbounded/imp.rs
+++ b/src/spmc/unbounded/imp.rs
@@ -117,7 +117,7 @@ impl<'a, T: Sendable+'a> Packet<'a, T> {
         if self.num_receivers.load(SeqCst) == 0 {
             return Err((val, Error::Disconnected));
         }
-        
+
         let new_end = Node::new();
 
         // See the comment in the unbounded SPSC implementation.
@@ -146,7 +146,7 @@ impl<'a, T: Sendable+'a> Packet<'a, T> {
                 Err(Error::Empty)
             };
         }
-        
+
         // We have to look at the node in read_end, read next, and then store next in
         // read_end. Unfortunately this is the classic ABA problem. Furthermore, if we
         // just load the value of read_end, then another thread could already deallocate
@@ -196,7 +196,6 @@ impl<'a, T: Sendable+'a> Packet<'a, T> {
 unsafe impl<'a, T: Sendable+'a> Send for Packet<'a, T> { }
 unsafe impl<'a, T: Sendable+'a> Sync for Packet<'a, T> { }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Packet<'a, T> {
     fn drop(&mut self) {
         while self.recv_async().is_ok() { }

--- a/src/spmc/unbounded/mod.rs
+++ b/src/spmc/unbounded/mod.rs
@@ -32,7 +32,6 @@ impl<'a, T: Sendable+'a> Producer<'a, T> {
     }
 }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Producer<'a, T> {
     fn drop(&mut self) {
         self.data.remove_sender()
@@ -74,7 +73,6 @@ impl<'a, T: Sendable+'a> Clone for Consumer<'a, T> {
     }
 }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Consumer<'a, T> {
     fn drop(&mut self) {
         self.data.remove_receiver()

--- a/src/spsc/bounded/imp.rs
+++ b/src/spsc/bounded/imp.rs
@@ -225,11 +225,10 @@ impl<'a, T: Sendable+'a> Packet<'a, T> {
 unsafe impl<'a, T: Sendable+'a> Send for Packet<'a, T> { }
 unsafe impl<'a, T: Sendable+'a> Sync for Packet<'a, T> { }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Packet<'a, T> {
     fn drop(&mut self) {
         let (write_pos, read_pos) = self.get_pos();
-        
+
         unsafe {
             for i in (0..write_pos-read_pos) {
                 ptr::read(self.buf.offset(((read_pos + i) & self.cap_mask) as isize));

--- a/src/spsc/bounded/mod.rs
+++ b/src/spsc/bounded/mod.rs
@@ -45,7 +45,6 @@ impl<'a, T: Sendable+'a> Producer<'a, T> {
     }
 }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Producer<'a, T> {
     fn drop(&mut self) {
         self.data.disconnect_sender()
@@ -80,7 +79,6 @@ impl<'a, T: Sendable+'a> Consumer<'a, T> {
     }
 }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Consumer<'a, T> {
     fn drop(&mut self) {
         self.data.disconnect_receiver()

--- a/src/spsc/one_space/imp.rs
+++ b/src/spsc/one_space/imp.rs
@@ -243,7 +243,6 @@ unsafe impl<'a, T: Sendable+'a> _Selectable<'a> for Packet<'a, T> {
     }
 }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Packet<'a, T> {
     fn drop(&mut self) {
         unsafe {

--- a/src/spsc/one_space/mod.rs
+++ b/src/spsc/one_space/mod.rs
@@ -44,7 +44,6 @@ impl<'a, T: Sendable+'a> Producer<'a, T> {
 
 unsafe impl<'a, T: Sendable+'a> Send for Producer<'a, T> { }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Producer<'a, T> {
     fn drop(&mut self) {
         self.data.sender_disconnect();
@@ -84,7 +83,6 @@ impl<'a, T: Sendable+'a> Consumer<'a, T> {
 
 unsafe impl<'a, T: Sendable+'a> Send for Consumer<'a, T> { }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Consumer<'a, T> {
     fn drop(&mut self) {
         self.data.recv_disconnect();

--- a/src/spsc/one_space/stack.rs
+++ b/src/spsc/one_space/stack.rs
@@ -44,7 +44,6 @@ impl<'a, T: Sendable+'a> Producer<'a, T> {
 
 unsafe impl<'a, T: Sendable+'a> Send for Producer<'a, T> { }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Producer<'a, T> {
     fn drop(&mut self) {
         self.data.sender_disconnect();
@@ -79,7 +78,6 @@ impl<'a, T: Sendable+'a> Consumer<'a, T> {
 
 unsafe impl<'a, T: Sendable+'a> Send for Consumer<'a, T> { }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Consumer<'a, T> {
     fn drop(&mut self) {
         self.data.recv_disconnect();

--- a/src/spsc/ring_buf/imp.rs
+++ b/src/spsc/ring_buf/imp.rs
@@ -207,11 +207,10 @@ impl<'a, T: Sendable+'a> Packet<'a, T> {
 unsafe impl<'a, T: Sendable+'a> Send for Packet<'a, T> { }
 unsafe impl<'a, T: Sendable+'a> Sync for Packet<'a, T> { }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Packet<'a, T> {
     fn drop(&mut self) {
         let (write_pos, read_pos) = self.get_pos();
-        
+
         unsafe {
             for i in (0..write_pos-read_pos) {
                 ptr::read(self.buf.offset(((read_pos + i) & self.cap_mask) as isize));

--- a/src/spsc/ring_buf/mod.rs
+++ b/src/spsc/ring_buf/mod.rs
@@ -41,7 +41,6 @@ impl<'a, T: Sendable+'a> Producer<'a, T> {
     }
 }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Producer<'a, T> {
     fn drop(&mut self) {
         self.data.disconnect_sender()
@@ -76,7 +75,6 @@ impl<'a, T: Sendable+'a> Consumer<'a, T> {
     }
 }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Consumer<'a, T> {
     fn drop(&mut self) {
         self.data.disconnect_receiver()

--- a/src/spsc/unbounded/imp.rs
+++ b/src/spsc/unbounded/imp.rs
@@ -120,7 +120,7 @@ impl<'a, T: Sendable+'a> Packet<'a, T> {
         if self.receiver_disconnected.load(SeqCst) {
             return Err((val, Error::Disconnected));
         }
-        
+
         let new_end = Node::new();
 
         // Some things to think about:
@@ -184,7 +184,6 @@ impl<'a, T: Sendable+'a> Packet<'a, T> {
 unsafe impl<'a, T: Sendable+'a> Send for Packet<'a, T> { }
 unsafe impl<'a, T: Sendable+'a> Sync for Packet<'a, T> { }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Packet<'a, T> {
     fn drop(&mut self) {
         while self.recv_async().is_ok() { }

--- a/src/spsc/unbounded/mod.rs
+++ b/src/spsc/unbounded/mod.rs
@@ -42,7 +42,6 @@ impl<'a, T: Sendable+'a> Producer<'a, T> {
     }
 }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Producer<'a, T> {
     fn drop(&mut self) {
         self.data.disconnect_sender()
@@ -77,7 +76,6 @@ impl<'a, T: Sendable+'a> Consumer<'a, T> {
     }
 }
 
-#[unsafe_destructor]
 impl<'a, T: Sendable+'a> Drop for Consumer<'a, T> {
     fn drop(&mut self) {
         self.data.disconnect_receiver()


### PR DESCRIPTION
There's a new warning for mixing #[repr(C)] and Drop, but that's temporary
so I figured it's fine. I can add an #[allow] for it if you want though.
