### PR TITLE
Removed all unneeded explicit lifetimes

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -8,7 +8,11 @@
 //! ### Example
 //!
 //! ```
+//! #![feature(core)]
+//!
 //! use comm::arc::{Arc, ArcTrait};
+//! use std::ptr;
+//! use std::raw::TraitObject;
 //!
 //! struct X {
 //!     x: u8
@@ -26,7 +30,7 @@
 //!
 //! let arc_trait: ArcTrait<Y> = unsafe {
 //!     let arc = Arc::new(X { x: 3 });
-//!     arc.as_trait(&*arc as &(Y+'static))
+//!     arc.as_trait(ptr::read(&(&*arc as &(Y+'static)) as *const _ as *const TraitObject))
 //! };
 //!
 //! assert_eq!(arc_trait.f(), 3);
@@ -39,7 +43,7 @@ use std::mem::{self, min_align_of, size_of};
 use core::nonzero::{NonZero};
 use std::ops::{Deref};
 use std::rt::heap::{deallocate};
-use std::raw::{TraitObject};
+use std::raw::TraitObject;
 use std::marker::{PhantomData};
 
 use {Sendable};
@@ -144,11 +148,9 @@ impl<T> Arc<T> {
 
     /// Creates an ArcTrait from an Arc. `t` must be a trait object created by calling
     /// `&*self as &Trait`. Otherwise the behavior is undefined.
-    pub unsafe fn as_trait<Trait: ?Sized>(&self, t: &Trait) -> ArcTrait<Trait> {
+    pub unsafe fn as_trait<Trait: ?Sized>(&self, t: TraitObject) -> ArcTrait<Trait> {
         assert!(mem::size_of::<&Trait>() == mem::size_of::<TraitObject>());
-
-        let _trait = ptr::read(&t as *const _ as *const TraitObject);
-        assert!(_trait.data as usize == &self.inner().data as *const _ as usize);
+        assert!(t.data as usize == &self.inner().data as *const _ as usize);
 
         self.inner().strong.fetch_add(1, Relaxed);
 
@@ -156,7 +158,7 @@ impl<T> Arc<T> {
             _size: mem::size_of::<ArcInner<T>>(),
             _alignment: mem::min_align_of::<ArcInner<T>>(),
             _destructor: ptr_drop::<T>,
-            _trait: _trait,
+            _trait: t,
 
             _ptr: mem::transmute(self._ptr),
 
@@ -477,6 +479,8 @@ impl<Trait: ?Sized> Drop for WeakTrait<Trait> {
 #[cfg(test)]
 mod test {
     use super::{Arc, ArcTrait};
+    use std::ptr;
+    use std::raw::TraitObject;
 
     struct X {
         x: u8
@@ -496,7 +500,7 @@ mod test {
     fn test1() {
         let arc_trait: ArcTrait<Y> = unsafe {
             let arc = Arc::new(X { x: 3 });
-            arc.as_trait(&*arc as &(Y+'static))
+            arc.as_trait(ptr::read(&(&*arc as &(Y+'static)) as *const _ as *const TraitObject))
         };
 
         assert_eq!(arc_trait.f(), 3);
@@ -506,7 +510,7 @@ mod test {
     fn test2() {
         let arc_trait: ArcTrait<Y> = unsafe {
             let arc = Arc::new(X { x: 3 });
-            arc.as_trait(&*arc as &(Y+'static))
+            arc.as_trait(ptr::read(&(&*arc as &(Y+'static)) as *const _ as *const TraitObject))
         };
         let weak = arc_trait.downgrade();
         let strong = weak.upgrade().unwrap();
@@ -518,7 +522,7 @@ mod test {
     fn test3() {
         let arc_trait: ArcTrait<Y> = unsafe {
             let arc = Arc::new(X { x: 3 });
-            arc.as_trait(&*arc as &(Y+'static))
+            arc.as_trait(ptr::read(&(&*arc as &(Y+'static)) as *const _ as *const TraitObject))
         };
         let weak = arc_trait.downgrade();
         drop(arc_trait);

--- a/src/mpsc/bounded_fast/imp.rs
+++ b/src/mpsc/bounded_fast/imp.rs
@@ -25,7 +25,7 @@ struct Node<T> {
 }
 
 #[repr(C)]
-pub struct Packet<'a, T: Sendable+'a> {
+pub struct Packet<T: Sendable> {
     // The id of this channel. The address of the `arc::Inner` that contains this channel.
     id: Cell<usize>,
 
@@ -56,11 +56,11 @@ pub struct Packet<'a, T: Sendable+'a> {
 
     // Is any one selecting on this channel?
     wait_queue_used: AtomicBool,
-    wait_queue: Mutex<WaitQueue<'a>>,
+    wait_queue: Mutex<WaitQueue>,
 }
 
-impl<'a, T: Sendable+'a> Packet<'a, T> {
-    pub fn new(mut buf_size: usize) -> Packet<'a, T> {
+impl<T: Sendable> Packet<T> {
+    pub fn new(mut buf_size: usize) -> Packet<T> {
         buf_size = cmp::max(buf_size, 2);
         let cap = buf_size.checked_next_power_of_two().unwrap_or(!0);
         let size = cap.checked_mul(mem::size_of::<Node<T>>()).unwrap_or(!0);
@@ -286,10 +286,10 @@ impl<'a, T: Sendable+'a> Packet<'a, T> {
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> Send for Packet<'a, T> { }
-unsafe impl<'a, T: Sendable+'a> Sync for Packet<'a, T> { }
+unsafe impl<T: Sendable> Send for Packet<T> { }
+unsafe impl<T: Sendable> Sync for Packet<T> { }
 
-impl<'a, T: Sendable+'a> Drop for Packet<'a, T> {
+impl<T: Sendable> Drop for Packet<T> {
     fn drop(&mut self) {
         while self.recv_async(false).is_ok() { }
 
@@ -301,7 +301,7 @@ impl<'a, T: Sendable+'a> Drop for Packet<'a, T> {
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> _Selectable<'a> for Packet<'a, T> {
+unsafe impl<T: Sendable> _Selectable for Packet<T> {
     fn ready(&self) -> bool {
         if self.num_senders.load(SeqCst) == 0 {
             return true;
@@ -311,7 +311,7 @@ unsafe impl<'a, T: Sendable+'a> _Selectable<'a> for Packet<'a, T> {
         node.pos.load(SeqCst) as isize - 1 - next_read as isize >= 0
     }
 
-    fn register(&self, load: Payload<'a>) {
+    fn register(&self, load: Payload) {
         let mut wait_queue = self.wait_queue.lock().unwrap();
         if wait_queue.add(load) > 0 {
             self.wait_queue_used.store(true, SeqCst);

--- a/src/mpsc/unbounded/imp.rs
+++ b/src/mpsc/unbounded/imp.rs
@@ -7,7 +7,7 @@ use std::cell::{Cell};
 use select::{_Selectable, WaitQueue, Payload};
 use {Error, Sendable};
 
-pub struct Packet<'a, T: Sendable+'a> {
+pub struct Packet<T: Sendable> {
     // The id of this channel. The address of the `arc::Inner` containing this channel.
     id: Cell<usize>,
 
@@ -31,7 +31,7 @@ pub struct Packet<'a, T: Sendable+'a> {
 
     // Is anyone selecting on this channel?
     wait_queue_used: AtomicBool,
-    wait_queue: Mutex<WaitQueue<'a>>,
+    wait_queue: Mutex<WaitQueue>,
 }
 
 struct Node<T: Sendable> {
@@ -52,8 +52,8 @@ impl<T: Sendable> Node<T> {
     }
 }
 
-impl<'a, T: Sendable+'a> Packet<'a, T> {
-    pub fn new() -> Packet<'a, T> {
+impl<T: Sendable> Packet<T> {
+    pub fn new() -> Packet<T> {
         let ptr = Node::new();
         Packet {
             id: Cell::new(0),
@@ -173,17 +173,17 @@ impl<'a, T: Sendable+'a> Packet<'a, T> {
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> Send for Packet<'a, T> { }
-unsafe impl<'a, T: Sendable+'a> Sync for Packet<'a, T> { }
+unsafe impl<T: Sendable> Send for Packet<T> { }
+unsafe impl<T: Sendable> Sync for Packet<T> { }
 
-impl<'a, T: Sendable+'a> Drop for Packet<'a, T> {
+impl<T: Sendable> Drop for Packet<T> {
     fn drop(&mut self) {
         while self.recv_async().is_ok() { }
         unsafe { ptr::read(self.read_end.load(SeqCst)); }
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> _Selectable<'a> for Packet<'a, T> {
+unsafe impl<T: Sendable> _Selectable for Packet<T> {
     fn ready(&self) -> bool {
         if self.num_senders.load(SeqCst) == 0 {
             return true;
@@ -192,7 +192,7 @@ unsafe impl<'a, T: Sendable+'a> _Selectable<'a> for Packet<'a, T> {
         !read_end.next.load(SeqCst).is_null()
     }
 
-    fn register(&self, load: Payload<'a>) {
+    fn register(&self, load: Payload) {
         let mut wait_queue = self.wait_queue.lock().unwrap();
         if wait_queue.add(load) > 0 {
             self.wait_queue_used.store(true, SeqCst);

--- a/src/mpsc/unbounded/mod.rs
+++ b/src/mpsc/unbounded/mod.rs
@@ -5,24 +5,26 @@
 use arc::{Arc, ArcTrait};
 use select::{Selectable, _Selectable};
 use {Error, Sendable};
+use std::ptr;
+use std::raw::TraitObject;
 
 mod imp;
 #[cfg(test)] mod test;
 #[cfg(test)] mod bench;
 
 /// Creates a new unbounded MPSC channel.
-pub fn new<'a, T: Sendable+'a>() -> (Producer<'a, T>, Consumer<'a, T>) {
+pub fn new<T: Sendable>() -> (Producer<T>, Consumer<T>) {
     let packet = Arc::new(imp::Packet::new());
     packet.set_id(packet.unique_id());
     (Producer { data: packet.clone() }, Consumer { data: packet })
 }
 
 /// The producing end of an unbounded MPSC channel.
-pub struct Producer<'a, T: Sendable+'a> {
-    data: Arc<imp::Packet<'a, T>>,
+pub struct Producer<T: Sendable> {
+    data: Arc<imp::Packet<T>>,
 }
 
-impl<'a, T: Sendable+'a> Producer<'a, T> {
+impl<T: Sendable> Producer<T> {
     /// Appends a message to the channel.
     ///
     /// ### Error
@@ -33,27 +35,27 @@ impl<'a, T: Sendable+'a> Producer<'a, T> {
     }
 }
 
-impl<'a, T: Sendable+'a> Clone for Producer<'a, T> {
-    fn clone(&self) -> Producer<'a, T> {
+impl<T: Sendable> Clone for Producer<T> {
+    fn clone(&self) -> Producer<T> {
         self.data.add_sender();
         Producer { data: self.data.clone() }
     }
 }
 
-impl<'a, T: Sendable+'a> Drop for Producer<'a, T> {
+impl<T: Sendable> Drop for Producer<T> {
     fn drop(&mut self) {
         self.data.remove_sender()
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> Send for Producer<'a, T> { }
+unsafe impl<T: Sendable> Send for Producer<T> { }
 
 /// The consuming end of an unbounded MPSC channel.
-pub struct Consumer<'a, T: Sendable+'a> {
-    data: Arc<imp::Packet<'a, T>>,
+pub struct Consumer<T: Sendable> {
+    data: Arc<imp::Packet<T>>,
 }
 
-impl<'a, T: Sendable+'a> Consumer<'a, T> {
+impl<T: Sendable> Consumer<T> {
     /// Receives a message from this channel. Blocks if the channel is empty.
     ///
     /// ### Error
@@ -74,20 +76,20 @@ impl<'a, T: Sendable+'a> Consumer<'a, T> {
     }
 }
 
-impl<'a, T: Sendable+'a> Drop for Consumer<'a, T> {
+impl<T: Sendable> Drop for Consumer<T> {
     fn drop(&mut self) {
         self.data.remove_receiver()
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> Send for Consumer<'a, T> { }
+unsafe impl<T: Sendable> Send for Consumer<T> { }
 
-impl<'a, T: Sendable+'a> Selectable<'a> for Consumer<'a, T> {
+impl<T: Sendable> Selectable for Consumer<T> {
     fn id(&self) -> usize {
         self.data.unique_id()
     }
 
-    fn as_selectable(&self) -> ArcTrait<_Selectable<'a>+'a> {
-        unsafe { self.data.as_trait(&*self.data as &(_Selectable+'a)) }
+    fn as_selectable(&self) -> ArcTrait<_Selectable> {
+        unsafe { self.data.as_trait(ptr::read(&(&*self.data as &(_Selectable)) as *const _ as *const TraitObject)) }
     }
 }

--- a/src/select/mod.rs
+++ b/src/select/mod.rs
@@ -37,7 +37,7 @@
 //! `wait` will return an increasing number of unique ids that should be compared to the
 //! return values of the `id` functions of `Selectable` objects. Therefore, all ready
 //! targets can be found in `O(number_of_targets)` or
-//! `number_of_ready_targets*O(log(number_of_targets))`. 
+//! `number_of_ready_targets*O(log(number_of_targets))`.
 //!
 //! ### Implementation
 //!
@@ -73,11 +73,11 @@ mod imp;
 // Traits are here because https://github.com/rust-lang/rust/issues/16264
 
 /// An object that can be selected on.
-pub trait Selectable<'a> {
+pub trait Selectable {
     /// Returns the id stored by `Select::wait` when this object is ready.
     fn id(&self) -> usize;
     /// Returns the interior object that will be stored in the `Select` object.
-    fn as_selectable(&self) -> ArcTrait<_Selectable<'a>+'a>;
+    fn as_selectable(&self) -> ArcTrait<_Selectable>;
 }
 
 /// The object that will be stored in a `Select` structure while the `Selectable` object
@@ -85,7 +85,7 @@ pub trait Selectable<'a> {
 ///
 /// Implementing this trait is unsafe because the behavior is undefined if the
 /// implementation doesn't follow the rules below.
-pub unsafe trait _Selectable<'a>: Sync+Sendable {
+pub unsafe trait _Selectable: Sync+Sendable {
     /// Returns `true` if the object is ready, `false` otherwise.
     ///
     /// This function must not try to acquire any locks that are also held while the
@@ -93,7 +93,7 @@ pub unsafe trait _Selectable<'a>: Sync+Sendable {
     fn ready(&self) -> bool;
     /// Registers a `Select` object with the `Selectable` object. The payload must be
     /// passed to the `WaitQueue`.
-    fn register(&self, Payload<'a>);
+    fn register(&self, Payload);
     /// Unregisters a `Select` objects from the `Selectable` object. The id must be passed
     /// to the `WaitQueue`.
     fn unregister(&self, id: usize);

--- a/src/spmc/bounded_fast/mod.rs
+++ b/src/spmc/bounded_fast/mod.rs
@@ -3,6 +3,8 @@
 use arc::{Arc, ArcTrait};
 use select::{Selectable, _Selectable};
 use {Error, Sendable};
+use std::ptr;
+use std::raw::TraitObject;
 
 mod imp;
 #[cfg(test)] mod test;
@@ -14,18 +16,18 @@ mod imp;
 /// This is unsafe because under just the right circumstances this implementation can lead
 /// to undefined behavior. Note that these circumstances are extremely rare and almost
 /// impossible on 64 bit systems.
-pub unsafe fn new<'a, T: Sendable+'a>(cap: usize) -> (Producer<'a, T>, Consumer<'a, T>) {
+pub unsafe fn new<T: Sendable>(cap: usize) -> (Producer<T>, Consumer<T>) {
     let packet = Arc::new(imp::Packet::new(cap));
     packet.set_id(packet.unique_id());
     (Producer { data: packet.clone() }, Consumer { data: packet })
 }
 
 /// A producer of a bounded SPMC channel.
-pub struct Producer<'a, T: Sendable+'a> {
-    data: Arc<imp::Packet<'a, T>>,
+pub struct Producer<T: Sendable> {
+    data: Arc<imp::Packet<T>>,
 }
 
-impl<'a, T: Sendable+'a> Producer<'a, T> {
+impl<T: Sendable> Producer<T> {
     /// Sends a message over the channel. Blocks if the channel is full.
     ///
     /// ### Error
@@ -46,20 +48,20 @@ impl<'a, T: Sendable+'a> Producer<'a, T> {
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> Send for Producer<'a, T> { }
+unsafe impl<T: Sendable> Send for Producer<T> { }
 
-impl<'a, T: Sendable+'a> Drop for Producer<'a, T> {
+impl<T: Sendable> Drop for Producer<T> {
     fn drop(&mut self) {
         self.data.remove_sender();
     }
 }
 
 /// A consumer of a bounded SPMC channel.
-pub struct Consumer<'a, T: Sendable+'a> {
-    data: Arc<imp::Packet<'a, T>>,
+pub struct Consumer<T: Sendable> {
+    data: Arc<imp::Packet<T>>,
 }
 
-impl<'a, T: Sendable+'a> Consumer<'a, T> {
+impl<T: Sendable> Consumer<T> {
     /// Receives a message from the channel. Blocks if the channel is empty.
     ///
     /// ### Error
@@ -80,27 +82,27 @@ impl<'a, T: Sendable+'a> Consumer<'a, T> {
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> Send for Consumer<'a, T> { }
+unsafe impl<T: Sendable> Send for Consumer<T> { }
 
-impl<'a, T: Sendable+'a> Clone for Consumer<'a, T> {
-    fn clone(&self) -> Consumer<'a, T> {
+impl<T: Sendable> Clone for Consumer<T> {
+    fn clone(&self) -> Consumer<T> {
         self.data.add_receiver();
         Consumer { data: self.data.clone(), }
     }
 }
 
-impl<'a, T: Sendable+'a> Drop for Consumer<'a, T> {
+impl<T: Sendable> Drop for Consumer<T> {
     fn drop(&mut self) {
         self.data.remove_receiver();
     }
 }
 
-impl<'a, T: Sendable+'a> Selectable<'a> for Consumer<'a, T> {
+impl<T: Sendable> Selectable for Consumer<T> {
     fn id(&self) -> usize {
         self.data.unique_id()
     }
 
-    fn as_selectable(&self) -> ArcTrait<_Selectable<'a>+'a> {
-        unsafe { self.data.as_trait(&*self.data as &(_Selectable+'a)) }
+    fn as_selectable(&self) -> ArcTrait<_Selectable> {
+        unsafe { self.data.as_trait(ptr::read(&(&*self.data as &(_Selectable)) as *const _ as *const TraitObject)) }
     }
 }

--- a/src/spmc/unbounded/imp.rs
+++ b/src/spmc/unbounded/imp.rs
@@ -7,7 +7,7 @@ use std::cell::{Cell};
 use select::{_Selectable, WaitQueue, Payload};
 use {Error, Sendable};
 
-pub struct Packet<'a, T: Sendable+'a> {
+pub struct Packet<T: Sendable> {
     // The id of this channel. The address of the `arc::Inner` that contains this channel.
     id: Cell<usize>,
 
@@ -33,7 +33,7 @@ pub struct Packet<'a, T: Sendable+'a> {
 
     // Is someone selecting on this channel?
     wait_queue_used: AtomicBool,
-    wait_queue: Mutex<WaitQueue<'a>>,
+    wait_queue: Mutex<WaitQueue>,
 }
 
 struct Node<T: Sendable> {
@@ -54,8 +54,8 @@ impl<T: Sendable> Node<T> {
     }
 }
 
-impl<'a, T: Sendable+'a> Packet<'a, T> {
-    pub fn new() -> Packet<'a, T> {
+impl<T: Sendable> Packet<T> {
+    pub fn new() -> Packet<T> {
         let ptr = Node::new();
         Packet {
             id: Cell::new(0),
@@ -193,22 +193,22 @@ impl<'a, T: Sendable+'a> Packet<'a, T> {
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> Send for Packet<'a, T> { }
-unsafe impl<'a, T: Sendable+'a> Sync for Packet<'a, T> { }
+unsafe impl<T: Sendable> Send for Packet<T> { }
+unsafe impl<T: Sendable> Sync for Packet<T> { }
 
-impl<'a, T: Sendable+'a> Drop for Packet<'a, T> {
+impl<T: Sendable> Drop for Packet<T> {
     fn drop(&mut self) {
         while self.recv_async().is_ok() { }
         unsafe { ptr::read(self.read_end.load(SeqCst)); }
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> _Selectable<'a> for Packet<'a, T> {
+unsafe impl<T: Sendable> _Selectable for Packet<T> {
     fn ready(&self) -> bool {
         !self.have_sender.load(SeqCst) || self.num_queued.load(SeqCst) > 0
     }
 
-    fn register(&self, load: Payload<'a>) {
+    fn register(&self, load: Payload) {
         let mut wait_queue = self.wait_queue.lock().unwrap();
         if wait_queue.add(load) > 0 {
             self.wait_queue_used.store(true, SeqCst);

--- a/src/spmc/unbounded/mod.rs
+++ b/src/spmc/unbounded/mod.rs
@@ -5,23 +5,25 @@
 use arc::{Arc, ArcTrait};
 use select::{Selectable, _Selectable};
 use {Error, Sendable};
+use std::ptr;
+use std::raw::TraitObject;
 
 mod imp;
 #[cfg(test)] mod test;
 
 /// Creates a new unbounded SPMC channel.
-pub fn new<'a, T: Sendable+'a>() -> (Producer<'a, T>, Consumer<'a, T>) {
+pub fn new<T: Sendable>() -> (Producer<T>, Consumer<T>) {
     let packet = Arc::new(imp::Packet::new());
     packet.set_id(packet.unique_id());
     (Producer { data: packet.clone() }, Consumer { data: packet })
 }
 
 /// The producing end of an unbounded SPMC channel.
-pub struct Producer<'a, T: Sendable+'a> {
-    data: Arc<imp::Packet<'a, T>>,
+pub struct Producer<T: Sendable> {
+    data: Arc<imp::Packet<T>>,
 }
 
-impl<'a, T: Sendable+'a> Producer<'a, T> {
+impl<T: Sendable> Producer<T> {
     /// Appends a message to the channel.
     ///
     /// ### Error
@@ -32,20 +34,20 @@ impl<'a, T: Sendable+'a> Producer<'a, T> {
     }
 }
 
-impl<'a, T: Sendable+'a> Drop for Producer<'a, T> {
+impl<T: Sendable> Drop for Producer<T> {
     fn drop(&mut self) {
         self.data.remove_sender()
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> Send for Producer<'a, T> { }
+unsafe impl<T: Sendable> Send for Producer<T> { }
 
 /// The receiving end of an unbounded SPMC channel.
-pub struct Consumer<'a, T: Sendable+'a> {
-    data: Arc<imp::Packet<'a, T>>,
+pub struct Consumer<T: Sendable> {
+    data: Arc<imp::Packet<T>>,
 }
 
-impl<'a, T: Sendable+'a> Consumer<'a, T> {
+impl<T: Sendable> Consumer<T> {
     /// Receives a message from the channel. Blocks if the channel is empty.
     ///
     /// ### Error
@@ -66,27 +68,27 @@ impl<'a, T: Sendable+'a> Consumer<'a, T> {
     }
 }
 
-impl<'a, T: Sendable+'a> Clone for Consumer<'a, T> {
-    fn clone(&self) -> Consumer<'a, T> {
+impl<T: Sendable> Clone for Consumer<T> {
+    fn clone(&self) -> Consumer<T> {
         self.data.add_receiver();
         Consumer { data: self.data.clone() }
     }
 }
 
-impl<'a, T: Sendable+'a> Drop for Consumer<'a, T> {
+impl<T: Sendable> Drop for Consumer<T> {
     fn drop(&mut self) {
         self.data.remove_receiver()
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> Send for Consumer<'a, T> { }
+unsafe impl<T: Sendable> Send for Consumer<T> { }
 
-impl<'a, T: Sendable+'a> Selectable<'a> for Consumer<'a, T> {
+impl<T: Sendable> Selectable for Consumer<T> {
     fn id(&self) -> usize {
         self.data.unique_id()
     }
 
-    fn as_selectable(&self) -> ArcTrait<_Selectable<'a>+'a> {
-        unsafe { self.data.as_trait(&*self.data as &(_Selectable+'a)) }
+    fn as_selectable(&self) -> ArcTrait<_Selectable> {
+        unsafe { self.data.as_trait(ptr::read(&(&*self.data as &(_Selectable)) as *const _ as *const TraitObject)) }
     }
 }

--- a/src/spsc/bounded/imp.rs
+++ b/src/spsc/bounded/imp.rs
@@ -11,7 +11,7 @@ use select::{_Selectable, WaitQueue, Payload};
 use alloc::{oom};
 use {Error, Sendable};
 
-pub struct Packet<'a, T: Sendable+'a> {
+pub struct Packet<T: Sendable> {
     // Id of the channel. Address of the arc::Inner that contains us.
     id: Cell<usize>,
 
@@ -39,11 +39,11 @@ pub struct Packet<'a, T: Sendable+'a> {
 
     // Is someone selecting on this channel?
     wait_queue_used: AtomicBool,
-    wait_queue: Mutex<WaitQueue<'a>>,
+    wait_queue: Mutex<WaitQueue>,
 }
 
-impl<'a, T: Sendable+'a> Packet<'a, T> {
-    pub fn new(buf_size: usize) -> Packet<'a, T> {
+impl<T: Sendable> Packet<T> {
+    pub fn new(buf_size: usize) -> Packet<T> {
         let cap = buf_size.checked_next_power_of_two().expect("capacity overflow");
         let size = cap.checked_mul(mem::size_of::<T>()).unwrap_or(!0);
         if size >= !0 >> 1 {
@@ -222,10 +222,10 @@ impl<'a, T: Sendable+'a> Packet<'a, T> {
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> Send for Packet<'a, T> { }
-unsafe impl<'a, T: Sendable+'a> Sync for Packet<'a, T> { }
+unsafe impl<T: Sendable> Send for Packet<T> { }
+unsafe impl<T: Sendable> Sync for Packet<T> { }
 
-impl<'a, T: Sendable+'a> Drop for Packet<'a, T> {
+impl<T: Sendable> Drop for Packet<T> {
     fn drop(&mut self) {
         let (write_pos, read_pos) = self.get_pos();
 
@@ -243,7 +243,7 @@ impl<'a, T: Sendable+'a> Drop for Packet<'a, T> {
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> _Selectable<'a> for Packet<'a, T> {
+unsafe impl<T: Sendable> _Selectable for Packet<T> {
     fn ready(&self) -> bool {
         if self.sender_disconnected.load(SeqCst) {
             return true;
@@ -252,7 +252,7 @@ unsafe impl<'a, T: Sendable+'a> _Selectable<'a> for Packet<'a, T> {
         write_pos != read_pos
     }
 
-    fn register(&self, load: Payload<'a>) {
+    fn register(&self, load: Payload) {
         let mut wait_queue = self.wait_queue.lock().unwrap();
         if wait_queue.add(load) > 0 {
             self.wait_queue_used.store(true, SeqCst);

--- a/src/spsc/bounded/mod.rs
+++ b/src/spsc/bounded/mod.rs
@@ -3,6 +3,8 @@
 use arc::{Arc, ArcTrait};
 use select::{Selectable, _Selectable};
 use {Error, Sendable};
+use std::ptr;
+use std::raw::TraitObject;
 
 mod imp;
 #[cfg(test)] mod test;
@@ -13,18 +15,18 @@ mod imp;
 /// ### Panic
 ///
 /// Panics if `next_power_of_two(cap) * sizeof(T) >= isize::MAX`.
-pub fn new<'a, T: Sendable+'a>(cap: usize) -> (Producer<'a, T>, Consumer<'a, T>) {
+pub fn new<T: Sendable>(cap: usize) -> (Producer<T>, Consumer<T>) {
     let packet = Arc::new(imp::Packet::new(cap));
     packet.set_id(packet.unique_id());
     (Producer { data: packet.clone() }, Consumer { data: packet })
 }
 
 /// The producing half of a bounded SPSC channel.
-pub struct Producer<'a, T: Sendable+'a> {
-    data: Arc<imp::Packet<'a, T>>,
+pub struct Producer<T: Sendable> {
+    data: Arc<imp::Packet<T>>,
 }
 
-impl<'a, T: Sendable+'a> Producer<'a, T> {
+impl<T: Sendable> Producer<T> {
     /// Sends a message over the channel. Blocks if the buffer is full.
     ///
     /// ### Errors
@@ -45,20 +47,20 @@ impl<'a, T: Sendable+'a> Producer<'a, T> {
     }
 }
 
-impl<'a, T: Sendable+'a> Drop for Producer<'a, T> {
+impl<T: Sendable> Drop for Producer<T> {
     fn drop(&mut self) {
         self.data.disconnect_sender()
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> Send for Producer<'a, T> { }
+unsafe impl<T: Sendable> Send for Producer<T> { }
 
 /// The consuming half of a bounded SPSC channel.
-pub struct Consumer<'a, T: Sendable+'a> {
-    data: Arc<imp::Packet<'a, T>>,
+pub struct Consumer<T: Sendable> {
+    data: Arc<imp::Packet<T>>,
 }
 
-impl<'a, T: Sendable+'a> Consumer<'a, T> {
+impl<T: Sendable> Consumer<T> {
     /// Receives a message over this channel. Blocks until a message is available.
     ///
     /// ### Errors
@@ -79,20 +81,20 @@ impl<'a, T: Sendable+'a> Consumer<'a, T> {
     }
 }
 
-impl<'a, T: Sendable+'a> Drop for Consumer<'a, T> {
+impl<T: Sendable> Drop for Consumer<T> {
     fn drop(&mut self) {
         self.data.disconnect_receiver()
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> Send for Consumer<'a, T> { }
+unsafe impl<T: Sendable> Send for Consumer<T> { }
 
-impl<'a, T: Sendable+'a> Selectable<'a> for Consumer<'a, T> {
+impl<T: Sendable> Selectable for Consumer<T> {
     fn id(&self) -> usize {
         self.data.unique_id()
     }
 
-    fn as_selectable(&self) -> ArcTrait<_Selectable<'a>+'a> {
-        unsafe { self.data.as_trait(&*self.data as &(_Selectable+'a)) }
+    fn as_selectable(&self) -> ArcTrait<_Selectable> {
+        unsafe { self.data.as_trait(ptr::read(&(&*self.data as &(_Selectable)) as *const _ as *const TraitObject)) }
     }
 }

--- a/src/spsc/one_space/imp.rs
+++ b/src/spsc/one_space/imp.rs
@@ -23,7 +23,7 @@ const WAIT_QUEUE_USED:       usize = 0b100000;
 
 const RECEIVER_FLAGS: usize = RECEIVER_WORKING|RECEIVER_SLEEPING|RECEIVER_DISCONNECTED;
 
-pub struct Packet<'a, T: Sendable+'a> {
+pub struct Packet<T: Sendable> {
     // Id of this channel. Address of the arc::Inner that contains this channel.
     id:               Cell<usize>,
     // A collection of flags, see above.
@@ -34,12 +34,12 @@ pub struct Packet<'a, T: Sendable+'a> {
     data:             UnsafeCell<Option<T>>,
     // Mutex to synchronize wait_queue access.
     wait_queue_mutex: StaticMutex,
-    wait_queue:       UnsafeCell<WaitQueue<'a>>,
+    wait_queue:       UnsafeCell<WaitQueue>,
 }
 
-impl<'a, T: Sendable+'a> Packet<'a, T> {
+impl<T: Sendable> Packet<T> {
     /// Create a new Packet
-    pub fn new() -> Packet<'a, T> {
+    pub fn new() -> Packet<T> {
         Packet {
             id:               Cell::new(0),
             flags:            AtomicUsize::new(NONE),
@@ -213,7 +213,7 @@ impl<'a, T: Sendable+'a> Packet<'a, T> {
     }
 
     /// Get the wait queue.
-    pub fn wait_queue<F, U>(&self, f: F) -> U where F: FnOnce(&mut WaitQueue<'a>) -> U {
+    pub fn wait_queue<F, U>(&self, f: F) -> U where F: FnOnce(&mut WaitQueue) -> U {
         unsafe {
             let mutex: &'static StaticMutex = mem::transmute(&self.wait_queue_mutex);
             let _guard = mutex.lock().unwrap();
@@ -222,15 +222,15 @@ impl<'a, T: Sendable+'a> Packet<'a, T> {
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> Sync for Packet<'a, T> { }
-unsafe impl<'a, T: Sendable+'a> Send for Packet<'a, T> { }
+unsafe impl<T: Sendable> Sync for Packet<T> { }
+unsafe impl<T: Sendable> Send for Packet<T> { }
 
-unsafe impl<'a, T: Sendable+'a> _Selectable<'a> for Packet<'a, T> {
+unsafe impl<T: Sendable> _Selectable for Packet<T> {
     fn ready(&self) -> bool {
         self.flags.load(Ordering::SeqCst) & (DATA_AVAILABLE | SENDER_DISCONNECTED) != 0
     }
 
-    fn register(&self, load: Payload<'a>) {
+    fn register(&self, load: Payload) {
         if self.wait_queue(|q| q.add(load)) > 0 {
             self.flags.fetch_or(WAIT_QUEUE_USED, Ordering::SeqCst);
         }
@@ -243,7 +243,7 @@ unsafe impl<'a, T: Sendable+'a> _Selectable<'a> for Packet<'a, T> {
     }
 }
 
-impl<'a, T: Sendable+'a> Drop for Packet<'a, T> {
+impl<T: Sendable> Drop for Packet<T> {
     fn drop(&mut self) {
         unsafe {
             let mutex: &'static StaticMutex = mem::transmute(&self.wait_queue_mutex);

--- a/src/spsc/one_space/stack.rs
+++ b/src/spsc/one_space/stack.rs
@@ -5,18 +5,18 @@ use super::imp::{Packet};
 use {Error, Sendable};
 
 /// Creates a new SPSC one space channel.
-pub fn new<'a, T: Sendable+'a>() -> Slot<'a, T> {
+pub fn new<T: Sendable>() -> Slot<T> {
     Slot { data: Packet::new() }
 }
 
 /// Storage for an SPSC one space channel.
-pub struct Slot<'a, T: Sendable+'a> {
-    data: Packet<'a, T>,
+pub struct Slot<T: Sendable> {
+    data: Packet<T>,
 }
 
-impl<'a, T: Sendable+'a> Slot<'a, T> {
+impl<T: Sendable> Slot<T> {
     /// Split the slot into a producing and a consuming end.
-    pub fn split(&mut self) -> (&Producer<'a, T>, &Consumer<'a, T>) {
+    pub fn split(&mut self) -> (&Producer<T>, &Consumer<T>) {
         unsafe {
             let prod = mem::transmute_copy(&self);
             let cons = mem::transmute(self);
@@ -26,11 +26,11 @@ impl<'a, T: Sendable+'a> Slot<'a, T> {
 }
 
 /// The producing half of an SPSC one space channel.
-pub struct Producer<'a, T: Sendable+'a> {
-    data: Packet<'a, T>,
+pub struct Producer<T: Sendable> {
+    data: Packet<T>,
 }
 
-impl<'a, T: Sendable+'a> Producer<'a, T> {
+impl<T: Sendable> Producer<T> {
     /// Sends a message over this channel. Doesn't block if the channel is full.
     ///
     /// ### Error
@@ -42,20 +42,20 @@ impl<'a, T: Sendable+'a> Producer<'a, T> {
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> Send for Producer<'a, T> { }
+unsafe impl<T: Sendable> Send for Producer<T> { }
 
-impl<'a, T: Sendable+'a> Drop for Producer<'a, T> {
+impl<T: Sendable> Drop for Producer<T> {
     fn drop(&mut self) {
         self.data.sender_disconnect();
     }
 }
 
 /// The consuming half of an SPSC one space channel.
-pub struct Consumer<'a, T: Sendable+'a> {
-    data: Packet<'a, T>,
+pub struct Consumer<T: Sendable> {
+    data: Packet<T>,
 }
 
-impl<'a, T: Sendable+'a> Consumer<'a, T> {
+impl<T: Sendable> Consumer<T> {
     /// Receives a message from this channel. Doesn't block if the channel is empty.
     ///
     /// ### Error
@@ -76,9 +76,9 @@ impl<'a, T: Sendable+'a> Consumer<'a, T> {
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> Send for Consumer<'a, T> { }
+unsafe impl<T: Sendable> Send for Consumer<T> { }
 
-impl<'a, T: Sendable+'a> Drop for Consumer<'a, T> {
+impl<T: Sendable> Drop for Consumer<T> {
     fn drop(&mut self) {
         self.data.recv_disconnect();
     }

--- a/src/spsc/ring_buf/mod.rs
+++ b/src/spsc/ring_buf/mod.rs
@@ -10,6 +10,8 @@
 use arc::{Arc, ArcTrait};
 use select::{Selectable, _Selectable};
 use {Error, Sendable};
+use std::ptr;
+use std::raw::TraitObject;
 
 mod imp;
 #[cfg(test)] mod test;
@@ -19,18 +21,18 @@ mod imp;
 /// ### Panic
 ///
 /// Panics if `next_power_of_two(cap) * sizeof(T) >= isize::MAX`.
-pub fn new<'a, T: Sendable+'a>(cap: usize) -> (Producer<'a, T>, Consumer<'a, T>) {
+pub fn new<T: Sendable>(cap: usize) -> (Producer<T>, Consumer<T>) {
     let packet = Arc::new(imp::Packet::new(cap));
     packet.set_id(packet.unique_id());
     (Producer { data: packet.clone() }, Consumer { data: packet })
 }
 
 /// The producing half of an SPSC ring buffer channel.
-pub struct Producer<'a, T: Sendable+'a> {
-    data: Arc<imp::Packet<'a, T>>,
+pub struct Producer<T: Sendable> {
+    data: Arc<imp::Packet<T>>,
 }
 
-impl<'a, T: Sendable+'a> Producer<'a, T> {
+impl<T: Sendable> Producer<T> {
     /// Sends a message over this channel. Returns an older message if the buffer is full.
     ///
     /// ### Error
@@ -41,20 +43,20 @@ impl<'a, T: Sendable+'a> Producer<'a, T> {
     }
 }
 
-impl<'a, T: Sendable+'a> Drop for Producer<'a, T> {
+impl<T: Sendable> Drop for Producer<T> {
     fn drop(&mut self) {
         self.data.disconnect_sender()
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> Send for Producer<'a, T> { }
+unsafe impl<T: Sendable> Send for Producer<T> { }
 
 /// The sending half of an SPSC channel.
-pub struct Consumer<'a, T: Sendable+'a> {
-    data: Arc<imp::Packet<'a, T>>,
+pub struct Consumer<T: Sendable> {
+    data: Arc<imp::Packet<T>>,
 }
 
-impl<'a, T: Sendable+'a> Consumer<'a, T> {
+impl<T: Sendable> Consumer<T> {
     /// Receives a message from the channel. Blocks if the buffer is empty.
     ///
     /// ### Error
@@ -75,20 +77,20 @@ impl<'a, T: Sendable+'a> Consumer<'a, T> {
     }
 }
 
-impl<'a, T: Sendable+'a> Drop for Consumer<'a, T> {
+impl<T: Sendable> Drop for Consumer<T> {
     fn drop(&mut self) {
         self.data.disconnect_receiver()
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> Send for Consumer<'a, T> { }
+unsafe impl<T: Sendable> Send for Consumer<T> { }
 
-impl<'a, T: Sendable+'a> Selectable<'a> for Consumer<'a, T> {
+impl<T: Sendable> Selectable for Consumer<T> {
     fn id(&self) -> usize {
         self.data.unique_id()
     }
 
-    fn as_selectable(&self) -> ArcTrait<_Selectable<'a>+'a> {
-        unsafe { self.data.as_trait(&*self.data as &(_Selectable+'a)) }
+    fn as_selectable(&self) -> ArcTrait<_Selectable> {
+        unsafe { self.data.as_trait(ptr::read(&(&*self.data as &(_Selectable)) as *const _ as *const TraitObject)) }
     }
 }

--- a/src/spsc/unbounded/mod.rs
+++ b/src/spsc/unbounded/mod.rs
@@ -14,24 +14,26 @@
 use arc::{Arc, ArcTrait};
 use select::{Selectable, _Selectable};
 use {Error, Sendable};
+use std::ptr;
+use std::raw::TraitObject;
 
 mod imp;
 #[cfg(test)] mod test;
 #[cfg(test)] mod bench;
 
 /// Creates a new unbounded SPSC channel.
-pub fn new<'a, T: Sendable+'a>() -> (Producer<'a, T>, Consumer<'a, T>) {
+pub fn new<T: Sendable>() -> (Producer<T>, Consumer<T>) {
     let packet = Arc::new(imp::Packet::new());
     packet.set_id(packet.unique_id());
     (Producer { data: packet.clone() }, Consumer { data: packet })
 }
 
 /// The producing half on an unbounded SPSC channel.
-pub struct Producer<'a, T: Sendable+'a> {
-    data: Arc<imp::Packet<'a, T>>,
+pub struct Producer<T: Sendable> {
+    data: Arc<imp::Packet<T>>,
 }
 
-impl<'a, T: Sendable+'a> Producer<'a, T> {
+impl<T: Sendable> Producer<T> {
     /// Appends a new message to the channel.
     ///
     /// ### Error
@@ -42,20 +44,20 @@ impl<'a, T: Sendable+'a> Producer<'a, T> {
     }
 }
 
-impl<'a, T: Sendable+'a> Drop for Producer<'a, T> {
+impl<T: Sendable> Drop for Producer<T> {
     fn drop(&mut self) {
         self.data.disconnect_sender()
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> Send for Producer<'a, T> { }
+unsafe impl<T: Sendable> Send for Producer<T> { }
 
 /// The consuming half on an unbounded SPSC channel.
-pub struct Consumer<'a, T: Sendable+'a> {
-    data: Arc<imp::Packet<'a, T>>,
+pub struct Consumer<T: Sendable> {
+    data: Arc<imp::Packet<T>>,
 }
 
-impl<'a, T: Sendable+'a> Consumer<'a, T> {
+impl<T: Sendable> Consumer<T> {
     /// Receives a message from the channel. Blocks if the channel is empty.
     ///
     /// ### Error
@@ -76,20 +78,20 @@ impl<'a, T: Sendable+'a> Consumer<'a, T> {
     }
 }
 
-impl<'a, T: Sendable+'a> Drop for Consumer<'a, T> {
+impl<T: Sendable> Drop for Consumer<T> {
     fn drop(&mut self) {
         self.data.disconnect_receiver()
     }
 }
 
-unsafe impl<'a, T: Sendable+'a> Send for Consumer<'a, T> { }
+unsafe impl<T: Sendable> Send for Consumer<T> { }
 
-impl<'a, T: Sendable+'a> Selectable<'a> for Consumer<'a, T> {
+impl<T: Sendable> Selectable for Consumer<T> {
     fn id(&self) -> usize {
         self.data.unique_id()
     }
 
-    fn as_selectable(&self) -> ArcTrait<_Selectable<'a>+'a> {
-        unsafe { self.data.as_trait(&*self.data as &(_Selectable+'a)) }
+    fn as_selectable(&self) -> ArcTrait<_Selectable> {
+        unsafe { self.data.as_trait(ptr::read(&(&*self.data as &(_Selectable)) as *const _ as *const TraitObject)) }
     }
 }


### PR DESCRIPTION
Explicit lifetimes make it impossible for each end of a channel to have differing lifespans, even though internally channels support this.

For example the following code snippet for a timer would not compile without this modification:

``` rust
use comm::spsc::one_space;
use std::thread;

pub fn oneshot<'a>(ms: u32) -> one_space::Consumer<'a, ()> {
    let (tx, rx) = one_space::new();
    thread::spawn(move || {
        thread::sleep_ms(ms);
        tx.send(());
    });
    rx
}
```

This would fail with the following message:

```
src/timer.rs:5:17: 5:33 error: cannot infer an appropriate lifetime due to conflicting requirements
src/timer.rs:5  let (tx, rx) = one_space::new();
                               ^~~~~~~~~~~~~~~~
src/timer.rs:5:2: 5:34 note: first, the lifetime cannot outlive the destruction scope surrounding statement at 5:1...
src/timer.rs:5  let (tx, rx) = one_space::new();
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/timer.rs:5:17: 5:33 note: ...so that references are valid when the destructor runs
src/timer.rs:5  let (tx, rx) = one_space::new();
                               ^~~~~~~~~~~~~~~~
src/timer.rs:4:60: 11:2 note: but, the lifetime must be valid for the lifetime 'a as defined on the block at 4:59...
src/timer.rs:4 pub fn oneshot<'a>(ms: u32) -> one_space::Consumer<'a, ()> {
src/timer.rs:5  let (tx, rx) = one_space::new();
src/timer.rs:6     thread::spawn(move || {
src/timer.rs:7         thread::sleep_ms(ms);
src/timer.rs:8         tx.send(());
src/timer.rs:9     });
               ...
src/timer.rs:10:5: 10:7 note: ...so that expression is assignable (expected `comm::spsc::one_space::Consumer<'a, ()>`, found `comm::spsc::one_space::Consumer<'_, ()>`)
src/timer.rs:10     rx
```

The solution proposed in this pull request is to remove all explicit lifetimes, and instead lets the compiler infer these.

This change does break existing consumers of the API, both through the removal of lifetime specifiers, and by changing the interface of `as_trait`.

`as_trait` now takes a `TraitObject` instead of a `Trait`, and callers of this function need to change code of the form:

``` rust
unsafe { self.data.as_trait(&*self.data as &(_Selectable+'a)) }
```

to:

``` rust
unsafe { self.data.as_trait(ptr::read(&(&*self.data as &(_Selectable)) as *const _ as *const TraitObject)) }
```
