### PR TITLE
Use alloc::heap instead of std::rt::heap

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -38,7 +38,7 @@ use std::{fmt, ptr};
 use std::mem::{self, align_of, size_of};
 use core::nonzero::{NonZero};
 use std::ops::{Deref};
-use std::rt::heap::{deallocate};
+use alloc::heap::{deallocate};
 use std::raw::{TraitObject};
 use std::marker::{PhantomData};
 

--- a/src/mpmc/bounded/imp.rs
+++ b/src/mpmc/bounded/imp.rs
@@ -6,7 +6,7 @@ use std::{ptr, mem};
 use std::sync::atomic::{AtomicUsize, AtomicBool};
 use std::sync::atomic::Ordering::{SeqCst};
 use std::sync::{Mutex, Condvar};
-use std::rt::heap::{allocate, deallocate};
+use alloc::heap::{allocate, deallocate};
 use std::cell::{Cell};
 
 use select::{_Selectable, WaitQueue, Payload};

--- a/src/mpsc/bounded_fast/imp.rs
+++ b/src/mpsc/bounded_fast/imp.rs
@@ -2,7 +2,7 @@ use std::{ptr, mem, cmp};
 use std::sync::atomic::{AtomicUsize, AtomicBool};
 use std::sync::atomic::Ordering::{SeqCst};
 use std::sync::{Mutex, Condvar};
-use std::rt::heap::{allocate, deallocate};
+use alloc::heap::{allocate, deallocate};
 use std::cell::{Cell};
 
 use select::{_Selectable, WaitQueue, Payload};

--- a/src/spmc/bounded_fast/imp.rs
+++ b/src/spmc/bounded_fast/imp.rs
@@ -2,7 +2,7 @@ use std::{ptr, mem, cmp};
 use std::sync::atomic::{AtomicUsize, AtomicBool};
 use std::sync::atomic::Ordering::{SeqCst};
 use std::sync::{Mutex, Condvar};
-use std::rt::heap::{allocate, deallocate};
+use alloc::heap::{allocate, deallocate};
 use std::cell::{Cell};
 
 use select::{_Selectable, WaitQueue, Payload};

--- a/src/spsc/bounded/imp.rs
+++ b/src/spsc/bounded/imp.rs
@@ -4,7 +4,7 @@ use std::{ptr, mem};
 use std::sync::atomic::{AtomicUsize, AtomicBool};
 use std::sync::atomic::Ordering::{SeqCst};
 use std::sync::{Mutex, Condvar};
-use std::rt::heap::{allocate, deallocate};
+use alloc::heap::{allocate, deallocate};
 use std::cell::{Cell};
 
 use select::{_Selectable, WaitQueue, Payload};

--- a/src/spsc/ring_buf/imp.rs
+++ b/src/spsc/ring_buf/imp.rs
@@ -1,7 +1,7 @@
 use std::{ptr, mem};
 use std::sync::atomic::{AtomicUsize, AtomicBool, Ordering};
 use std::sync::{Mutex, Condvar};
-use std::rt::heap::{allocate, deallocate};
+use alloc::heap::{allocate, deallocate};
 use std::cell::{Cell};
 
 use select::{_Selectable, WaitQueue, Payload};


### PR DESCRIPTION
std::rt::heap is removed in the commit:
https://github.com/rust-lang/rust/commit/f4be2026dfb507e5db919cc5df8fd934e05fa0b8
