### PR TITLE
change one character to fix the table

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ features provided by this crate.
 
 ### Comparison with the `std::sync` implementation
 
-    | `std::sync` | `comm`
+_   | `std::sync` | `comm`
 ----| :----: | :----:
 Restricted by stability guarantees | ✔<sup>1</sup> | ✘
 Users can use their own channels with `Select` | ✘ | ✔


### PR DESCRIPTION
from rust-lang/rfcs#848 but this crate looks like has no changes at all in recent 2 years? wonder what happened in 2016 ? in 2017 ? is this still want to be a production ready mpmc channel for **Rust** ?

![image](https://user-images.githubusercontent.com/14798161/31313745-f2547522-aba0-11e7-838d-bb890cbe49a8.png)